### PR TITLE
Add option to only save items with "store_on_death" tag.

### DIFF
--- a/Common/src/main/java/com/natamus/youritemsaresafe/config/ConfigHandler.java
+++ b/Common/src/main/java/com/natamus/youritemsaresafe/config/ConfigHandler.java
@@ -23,6 +23,7 @@ public class ConfigHandler extends DuskConfig {
 	@Entry public static boolean sendMessageOnCreationFailure = true;
 	@Entry public static boolean sendMessageOnCreationSuccess = true;
 	@Entry public static boolean sendDeathCoordinatesInChat = true;
+	@Entry public static boolean useStoreOnDeathTag = false;
 	@Entry public static String creationFailureMessage = "Your items are not safe due to having insufficient materials. Missing: %plankamount% planks.";
 	@Entry public static String creationSuccessMessage = "Your items are safe at your death location.";
 
@@ -56,6 +57,9 @@ public class ConfigHandler extends DuskConfig {
 		));
 		configMetaData.put("createVoidPlatform", Arrays.asList(
 			"If a 3x3 platform should be created below the chest above the void. 'createChestAboveVoid' must be enabled."
+		));
+		configMetaData.put("useStoreOnDeathTag", Arrays.asList(
+			"If only items with store_on_death tag should be stored in the chest."
 		));
 		configMetaData.put("sendMessageOnCreationFailure", Arrays.asList(
 			"If a message should be sent if the chest or armor stand can't be created due to missing materials."

--- a/Common/src/main/java/com/natamus/youritemsaresafe/events/DeathEvent.java
+++ b/Common/src/main/java/com/natamus/youritemsaresafe/events/DeathEvent.java
@@ -41,7 +41,12 @@ public class DeathEvent {
 		String playerName = player.getName().getString();
 		
 		List<ItemStack> itemStacks = Util.getInventoryItems(player);
-		
+
+		if (ConfigHandler.useStoreOnDeathTag) {
+			itemStacks.removeIf(
+					itemStack -> itemStack.getTags().noneMatch(tagKey -> tagKey.toString().contains("store_on_death")));
+		}
+
 		int totalItemCount = 0;
 		for (ItemStack itemStack : itemStacks) {
 			if (!itemStack.isEmpty()) {


### PR DESCRIPTION
Adds an option useStoreOnDeath.

When it's active, only items with the matching tag store_on_death will be stored in the chest.
This can be combined with keepInventory true (which is my use case) to make a "keep some inventory" modality.

For example, in my case, I've created a datapack which matches all the tools and armors with the store_on_death tag. That together with keep inventory makes it so I keep my equipment but lose the rest.

For example: datapacks/YourItemsAreSafe/tags/items/store_on_death.json:
```datapacks/YourItemsAreSafe/tags/items/store_on_death.json
{
	"values": [
		{ "id": "acacia_button", "required": false },
		{ "id": "acacia_door", "required": false },
		{ "id": "acacia_fence", "required": false },
		{ "id": "acacia_fence_gate", "required": false },
		{ "id": "acacia_hanging_sign", "required": false },
                { "id": "coal", "required": false },
		{ "id": "coal_block", "required": false },
		{ "id": "coal_ore", "required": false },
		{ "id": "zombie_villager_spawn_egg", "required": false },
		{ "id": "zombified_piglin_spawn_egg", "required": false },
		{ "id": "minecraft:enchanted_golden_apple", "required": false }
	]
}

```

I'm frustrated because I wanted this for a server that opens Nov 16 and I really wanted it to have it but the build process with Collective turned out to be too complicated for my brain. I use other mods from that depend on Collective so just using the uncompiled version I found in the comments here (https://github.com/Serilum/.issue-tracker/issues/2508) is not an option for me.

This implementation is a bit rigid imo. Maybe the tag should be configurable, but this is what I needed so I left it like this.

Hope someday the "keep some inventory" mode gets more popularity on the Minecraft community 🙏 